### PR TITLE
Contributing Info - Add Projects

### DIFF
--- a/live/projects.json
+++ b/live/projects.json
@@ -10320,7 +10320,7 @@
       
     ],
     "primaryTopic":null,
-    "beginnerIssuesLabel":"community"
+    "beginnerIssuesLabel":"help:community"
   },
   "lambdista/config":{
     "contributorsWanted":false,
@@ -19821,7 +19821,7 @@
     ],
     "customScalaDoc":null,
     "documentationLinks":[
-    
+
     ],
     "primaryTopic":null
   },

--- a/live/projects.json
+++ b/live/projects.json
@@ -483,7 +483,11 @@
         "Reference Documentation (Scala)":"http://doc.akka.io/docs/akka/[version]/scala.html"
       }
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"community",
+    "chatroom":{
+      "target":"https://gitter.im/akka/dev"
+    }
   },
   "akka/akka-http":{
     "contributorsWanted":false,
@@ -505,7 +509,11 @@
         "Documentation":"http://doc.akka.io/docs/akka-http/[version]/scala/http/index.html"
       }
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"community",
+    "chatroom":{
+      "target":"https://gitter.im/akka/dev"
+    }
   },
   "akka/akka-persistence-cassandra":{
     "contributorsWanted":true,
@@ -3056,7 +3064,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":"json"
+    "primaryTopic":"json",
+    "beginnerIssuesLabel":"beginner-friendly"
   },
   "circe/circe-jackson":{
     "contributorsWanted":false,
@@ -4196,7 +4205,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"help wanted"
   },
   "deeplearning4j/nd4j":{
     "contributorsWanted":false,
@@ -5060,7 +5070,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"low-hanging fruit"
   },
   "envisia/play-quill":{
     "contributorsWanted":false,
@@ -5569,7 +5580,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":"http"
+    "primaryTopic":"http",
+    "beginnerIssuesLabel":"easy"
   },
   "fix-macosx/net-monitor":{
     "contributorsWanted":false,
@@ -6317,7 +6329,11 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Low Hanging Fruit",
+    "chatroom":{
+      "target":"https://groups.google.com/forum/#!forum/gatling"
+    }
   },
   "gatling/jsonpath":{
     "contributorsWanted":false,
@@ -6457,7 +6473,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"easy"
   },
   "getryft/spark-ryft-connector":{
     "contributorsWanted":false,
@@ -10302,7 +10319,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"community"
   },
   "lambdista/config":{
     "contributorsWanted":false,
@@ -10362,7 +10380,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"exp:novice"
   },
   "larroy/milight":{
     "contributorsWanted":false,
@@ -10654,7 +10673,8 @@
         "Simply Lift":"https://simply.liftweb.net/"
       }
     ],
-    "primaryTopic":"lift"
+    "primaryTopic":"lift",
+    "beginnerIssuesLabel":"easy"
   },
   "liftmodules/imaging":{
     "contributorsWanted":false,
@@ -11156,7 +11176,11 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"beginner-level",
+    "chatroom":{
+      "target":"https://gitter.im/geotrellis/geotrellis"
+    }
   },
   "logimethods/nats-connector-gatling":{
     "contributorsWanted":false,
@@ -12203,7 +12227,11 @@
         "User Guide":"https://github.com/underscoreio/shapeless-guide"
       }
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Low hanging fruit",
+    "contributingGuide":{
+      "target":"https://github.com/milessabin/shapeless#participation"
+    }
   },
   "mkotsur/aws-lambda-scala":{
     "contributorsWanted":false,
@@ -14944,7 +14972,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"newbie"
   },
   "playframework/twirl":{
     "contributorsWanted":false,
@@ -16246,7 +16275,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Spree"
   },
   "sbt/sbt-buildinfo":{
     "contributorsWanted":false,
@@ -16427,6 +16457,30 @@
       
     ],
     "primaryTopic":null
+  },
+  "sbt/zinc":{
+    "contributorsWanted":false,
+    "keywords":[
+
+    ],
+    "defaultArtifact":"zinc",
+    "defaultStableVersion":true,
+    "deprecated":false,
+    "artifactDeprecations":[
+
+    ],
+    "cliArtifacts":[
+
+    ],
+    "customScalaDoc":null,
+    "documentationLinks":[
+
+    ],
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"spree",
+    "chatroom":{
+      "target":"https://gitter.im/sbt/zinc-contrib"
+    }
   },
   "scala/async":{
     "contributorsWanted":false,
@@ -16908,6 +16962,27 @@
     ],
     "primaryTopic":null
   },
+  "scalacenter/scaladex":{
+    "contributorsWanted":false,
+    "keywords":[
+
+    ],
+    "defaultArtifact":"scaladex",
+    "defaultStableVersion":true,
+    "deprecated":false,
+    "artifactDeprecations":[
+
+    ],
+    "cliArtifacts":[
+
+    ],
+    "customScalaDoc":null,
+    "documentationLinks":[
+
+    ],
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Scala Spree"
+  },
   "scalacenter/scalafix":{
     "contributorsWanted":false,
     "keywords":[
@@ -16930,7 +17005,29 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":"refactoring"
+    "primaryTopic":"refactoring",
+    "beginnerIssuesLabel":"good first contribution"
+  },
+  "scalacenter/scalajs-bundler":{
+    "contributorsWanted":false,
+    "keywords":[
+
+    ],
+    "defaultArtifact":"scalajs-bundler",
+    "defaultStableVersion":true,
+    "deprecated":false,
+    "artifactDeprecations":[
+
+    ],
+    "cliArtifacts":[
+
+    ],
+    "customScalaDoc":null,
+    "documentationLinks":[
+
+    ],
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"low hanging fruit"
   },
   "scalaconsultants/reactive-rabbit":{
     "contributorsWanted":false,
@@ -17032,6 +17129,27 @@
     ],
     "primaryTopic":null
   },
+  "scalameta/scalafmt":{
+    "contributorsWanted":false,
+    "keywords":[
+
+    ],
+    "defaultArtifact":"scalafmt",
+    "defaultStableVersion":true,
+    "deprecated":false,
+    "artifactDeprecations":[
+
+    ],
+    "cliArtifacts":[
+
+    ],
+    "customScalaDoc":null,
+    "documentationLinks":[
+
+    ],
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"good first time contribution"
+  },
   "scalameta/scalameta":{
     "contributorsWanted":false,
     "keywords":[
@@ -17050,7 +17168,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Spree"
   },
   "scalameter/scalameter":{
     "contributorsWanted":false,
@@ -19456,7 +19575,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"effort: easy"
   },
   "slick/slick-examples":{
     "contributorsWanted":false,
@@ -19688,20 +19808,20 @@
   "softwaremill/sttp":{
     "contributorsWanted":false,
     "keywords":[
-      
+
     ],
     "defaultArtifact":"core",
     "defaultStableVersion":true,
     "deprecated":false,
     "artifactDeprecations":[
-      
+
     ],
     "cliArtifacts":[
-      
+
     ],
     "customScalaDoc":null,
     "documentationLinks":[
-      
+    
     ],
     "primaryTopic":null
   },
@@ -19803,7 +19923,11 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"newbie",
+    "contributingGuide":{
+      "target":"https://github.com/spark-jobserver/spark-jobserver#contribution-and-development"
+    }
   },
   "sparklinedata/spark-druid-olap":{
     "contributorsWanted":false,
@@ -21694,7 +21818,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"Starter"
   },
   "twitter/finatra":{
     "contributorsWanted":false,
@@ -21834,7 +21959,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"beginner"
   },
   "twitter/scrooge":{
     "contributorsWanted":false,
@@ -22059,7 +22185,8 @@
         "Scala Exercises / cats":"https://www.scala-exercises.org/cats"
       }
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"low-hanging fruit"
   },
   "typelevel/discipline":{
     "contributorsWanted":false,

--- a/live/projects.json
+++ b/live/projects.json
@@ -9657,7 +9657,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"low hanging fruit"
   },
   "julienrf/enum":{
     "contributorsWanted":false,
@@ -9737,7 +9738,8 @@
     "documentationLinks":[
       
     ],
-    "primaryTopic":null
+    "primaryTopic":null,
+    "beginnerIssuesLabel":"low hanging fruit"
   },
   "jvican/ujisso":{
     "contributorsWanted":false,


### PR DESCRIPTION
@heathermiller @MasseGuillaume As part of https://github.com/scalacenter/scaladex/pull/467

Added contributing info (mostly just beginner issues labels) for the following projects:
akka/akka
akka/akka-http
circe/circe
deeplearning4j/deeplearning4j
ensime/scala-debugger
finagle/finch
gatling/gatling
getquill/quill
lagom/lagom
lampepfl/dotty
lift/framework
locationtech/geotrellis
milessabin/shapeless
playframework/playframework
sbt/sbt
sbt/zinc
scalacenter/scaladex
scalacenter/scalafix
scalacenter/scalajs-bundler
scalameta/scalafmt
scalameta/scalameta
slick/slick
spark-jobserver/spark-jobserver
twitter/finagle
twitter/scalding
typelevel/cats

So the next time the server is re-indexed, the projects above will have contributing info and will be able to show up on the front page, in the Contributing Search, ... (once PR #467 is deployed of course).

1. Can you think of any other projects that should be added? They need to have issues on github with a beginner-friendly label, a chatroom and a contributing guide.

2. I noticed one problem with repos like scala/scala that have their issues tracked in a separate repo. The code currently assumes the issues are in the same repo as the code so I wasn't able to add scala/scala since it's issues aren't tracked in the same repo as the code. Should I add a feature to PR #467 to let maintainers specify a different repo for scaladex to get issues from (if they don't track issues in the same repo as their code) in the edit project page?